### PR TITLE
Fix get_editor_log returning the revision-control log instead of editor output

### DIFF
--- a/uefn_listener.py
+++ b/uefn_listener.py
@@ -503,29 +503,51 @@ def _cmd_focus_selected() -> dict:
 
 @_register("get_editor_log")
 def _cmd_get_editor_log(last_n: int = 100, filter_str: str = "") -> dict:
-    """Read recent lines from the UE Output Log file."""
-    log_path = unreal.Paths.project_log_dir()
+    """Read recent lines from the UE Output Log file.
+
+    The log directory holds several .log files written concurrently
+    (UnrealRevisionControl.log, cef3.log, the editor log, plus rotated
+    *-backup-* copies). Selecting the newest by mtime is wrong: the
+    revision-control / transport log is rewritten every few seconds and almost
+    always wins, returning auth spam instead of the editor output.
+
+    Instead, identify the editor log by name: it is the log whose filename
+    starts with the running application's prefix (e.g.
+    UnrealEditorFortnite.log, from sys.executable), excluding rotated backups.
+    If nothing matches the prefix we return an explicit error rather than
+    falling back to the newest log — guessing the newest unidentified file is
+    exactly the original bug, so this function returns the editor log or
+    nothing, never the wrong file.
+    """
+    log_dir = str(unreal.Paths.project_log_dir())
     log_file = None
+    error = None
     try:
         import os
-        log_dir = str(log_path)
-        # Find the most recent .log file
-        log_files = [f for f in os.listdir(log_dir) if f.endswith(".log")]
-        if log_files:
-            log_files.sort(key=lambda f: os.path.getmtime(os.path.join(log_dir, f)), reverse=True)
-            log_file = os.path.join(log_dir, log_files[0])
-    except Exception:
-        pass
+        # "UnrealEditorFortnite-Win64-Shipping" -> "UnrealEditorFortnite"
+        app_prefix = os.path.splitext(os.path.basename(sys.executable))[0].split("-")[0]
+        matching = [
+            f for f in os.listdir(log_dir)
+            if f.lower().endswith(".log") and "-backup-" not in f and f.startswith(app_prefix)
+        ]
+        if matching:
+            matching.sort(key=lambda f: os.path.getmtime(os.path.join(log_dir, f)), reverse=True)
+            log_file = os.path.join(log_dir, matching[0])
+        else:
+            error = f"No editor log matching prefix '{app_prefix}' in {log_dir}"
+    except Exception as e:
+        error = str(e)
 
     if not log_file:
-        return {"lines": [], "error": "Log file not found"}
+        return {"lines": [], "error": error or "Log file not found"}
 
     try:
         with open(log_file, "r", encoding="utf-8", errors="replace") as f:
             all_lines = f.readlines()
-        lines = all_lines[-last_n:]
+        # Filter before tailing so last_n counts matching lines, not raw lines.
         if filter_str:
-            lines = [l for l in lines if filter_str.lower() in l.lower()]
+            all_lines = [l for l in all_lines if filter_str.lower() in l.lower()]
+        lines = all_lines[-last_n:]
         return {"lines": [l.rstrip() for l in lines], "count": len(lines), "file": log_file}
     except Exception as e:
         return {"lines": [], "error": str(e)}


### PR DESCRIPTION
## Problem

`get_editor_log` returns the wrong file. It selects the most recently modified
`.log` in the project log directory:

    log_files.sort(key=lambda f: os.path.getmtime(...), reverse=True)
    log_file = log_files[0]

In UEFN that directory holds several logs written concurrently. The
revision-control / transport log (`UnrealRevisionControl.log`) is rewritten
every few seconds, so it almost always has the newest mtime and wins — the tool
returns `lore_transport::auth` spam instead of the editor Output Log
(`UnrealEditorFortnite.log`) with the LogVerse / LogPython / compile messages
users actually want.

### Reproduce
Call `get_editor_log` with the editor running and an active revision-control
connection. The returned lines are `[... Debug] [lore_transport::auth::exchange] ...`,
not editor output.

## Fix

Identify the editor log by name instead of by mtime:
- derive the app prefix from `sys.executable`
  (`UnrealEditorFortnite-Win64-Shipping` -> `UnrealEditorFortnite`),
- among `.log` files, keep those that start with that prefix and are not
  `-backup-` rotations, and return the newest of those.

If no file matches the prefix, return an explicit error
(`No editor log matching prefix '...'`) rather than falling back to the newest
log. Guessing the newest unidentified file is exactly the original bug, so the
function now returns the editor log or nothing — never the wrong file.

A small related fix in the same function: filter **before** tailing, so
`last_n` counts matching lines rather than dropping matches that sit above the
last `last_n` raw lines.

Single self-contained change to `_cmd_get_editor_log`; no other files touched,
no public API change.

## Verification

Verified live against UEFN: before, the tool returned `UnrealRevisionControl.log`
auth spam; after, it returns `UnrealEditorFortnite.log` (LogVerse / LogPython).
The log directory was inspected to confirm the selection, and `sys.executable`
inside the editor resolves to `UnrealEditorFortnite-Win64-Shipping.exe`, which
yields the `UnrealEditorFortnite` prefix.

This fix is covered by regression tests in my fork (lexosi/uefn-mcp-server) — a
positive control proving the original mtime selector picks the revision-control
log, plus a test that the fix avoids it. They rely on a small pytest harness I
kept out of this PR to stay minimal; happy to contribute it separately if useful.
